### PR TITLE
Update bnd tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.palladiosimulator</groupId>
@@ -108,6 +109,42 @@
 		</dependency>
 	</dependencies>
 
+	<profiles>
+		<!-- Build configuration of parent POM itself -->
+		<profile>
+			<id>local-build-deployable</id>
+			<!-- activate this profile explicitly by adding -Plocal-build-deployable to the maven command -->
+			<distributionManagement>
+				<snapshotRepository>
+					<id>ossrh</id>
+					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+				</snapshotRepository>
+				<repository>
+					<id>ossrh</id>
+					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+				</repository>
+			</distributionManagement>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.6</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -150,20 +187,6 @@
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>1.6</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -88,12 +88,12 @@
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>
 			<artifactId>biz.aQute.repository</artifactId>
-			<version>4.1.0</version>
+			<version>4.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>
 			<artifactId>biz.aQute.bndlib</artifactId>
-			<version>4.1.0</version>
+			<version>4.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/org/palladiosimulator/maven/tychotprefresh/tasks/impl/TargetPlatformUpdater.java
+++ b/src/main/java/org/palladiosimulator/maven/tychotprefresh/tasks/impl/TargetPlatformUpdater.java
@@ -67,8 +67,9 @@ public class TargetPlatformUpdater extends TargetPlatformTaskBase {
 			return updatedLocation;
 
 		} catch (URISyntaxException | IOException e) {
+			Throwable causeToReport = getLog().isDebugEnabled() ? e : null;
 			getLog().warn("Unable to retrieve repository contents. Skipping version update for location "
-					+ repositoryLocation);
+					+ repositoryLocation, causeToReport);
 			return locationToUpdate;
 		}
 	}


### PR DESCRIPTION
Use latest bnd tools version. The update is necessary because there was a hard coded path in versions prior to 4.3.0 that we need to override in container-based builds (see [commit](https://github.com/bndtools/bnd/commit/08c911ceb24febdfe58e578609187fdbdb84a4f5) in bndlib repository).