### PR TITLE
Install target platform in local repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
 			<version>3.3.1</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-compat</artifactId>
+			<version>3.3.1</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven.wagon</groupId>
 			<artifactId>wagon-http</artifactId>
 			<version>3.0.0</version>

--- a/src/main/java/org/palladiosimulator/maven/tychotprefresh/impl/TPRefresher.java
+++ b/src/main/java/org/palladiosimulator/maven/tychotprefresh/impl/TPRefresher.java
@@ -1,5 +1,6 @@
 package org.palladiosimulator.maven.tychotprefresh.impl;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -49,9 +50,9 @@ public class TPRefresher {
 
 	protected List<TargetPlatformTask> createTasks(MavenSession session, MavenProject rootProject,
 			PropertyGatherer properties) {
-		dependencies.setMavenSession(session);
 		dependencies.setRemoteRepositories(rootProject.getRemoteArtifactRepositories());
 		dependencies.setLocalRepository(session.getLocalRepository());
+		File tmpDir = new File(rootProject.getBuild().getDirectory());
 		
 		List<TargetPlatformTask> taskSequence = new ArrayList<>();
 		taskSequence.add(new TargetPlatformInitializer(dependencies, properties.getTpTargetLocations()));
@@ -59,7 +60,7 @@ public class TPRefresher {
 		taskSequence.add(new TargetPlatformUpdater(dependencies));
 		taskSequence.add(new TargetPlatformMerger(dependencies));
 		taskSequence.add(new TargetPlatformCopier(dependencies, rootProject, properties.getTpCopyDestinationFileName()));
-		taskSequence.add(new TargetPlatformAttacher(dependencies, properties.getTpProjectCoordinates()));
+		taskSequence.add(new TargetPlatformAttacher(dependencies, properties.getTpProjectCoordinates(), tmpDir));
 		return taskSequence;
 	}
 	

--- a/src/main/java/org/palladiosimulator/maven/tychotprefresh/tasks/TaskDependencies.java
+++ b/src/main/java/org/palladiosimulator/maven/tychotprefresh/tasks/TaskDependencies.java
@@ -2,15 +2,12 @@ package org.palladiosimulator.maven.tychotprefresh.tasks;
 
 import java.util.List;
 
+import org.apache.maven.artifact.installer.ArtifactInstaller;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.logging.Logger;
 import org.palladiosimulator.maven.tychotprefresh.util.IArtifactResolver;
 
 public interface TaskDependencies {
-
-	RepositorySystem getRepositorySystem();
 
 	IArtifactResolver getArtifactResolver();
 
@@ -18,8 +15,8 @@ public interface TaskDependencies {
 
 	ArtifactRepository getLocalRepository();
 
-	MavenSession getMavenSession();
-
 	Logger getLog();
+	
+	ArtifactInstaller getArtifactInstaller();
 
 }

--- a/src/main/java/org/palladiosimulator/maven/tychotprefresh/tasks/TaskDependenciesImpl.java
+++ b/src/main/java/org/palladiosimulator/maven/tychotprefresh/tasks/TaskDependenciesImpl.java
@@ -2,9 +2,8 @@ package org.palladiosimulator.maven.tychotprefresh.tasks;
 
 import java.util.List;
 
+import org.apache.maven.artifact.installer.ArtifactInstaller;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
@@ -18,15 +17,13 @@ public class TaskDependenciesImpl implements TaskDependenciesInitializable {
 	
 	@Requirement
 	protected IArtifactResolver artifactResolver;
-
+	
 	@Requirement
-	protected RepositorySystem repositorySystem;
+	protected ArtifactInstaller artifactInstaller;
 	
 	protected ArtifactRepository localRepository;
 	
 	protected List<ArtifactRepository> remoteRepositories;
-	
-	protected MavenSession mavenSession;
 
 	@Override
 	public ArtifactRepository getLocalRepository() {
@@ -54,23 +51,13 @@ public class TaskDependenciesImpl implements TaskDependenciesInitializable {
 	}
 
 	@Override
-	public RepositorySystem getRepositorySystem() {
-		return repositorySystem;
-	}
-
-	@Override
-	public MavenSession getMavenSession() {
-		return mavenSession;
-	}
-
-	@Override
-	public void setMavenSession(MavenSession mavenSession) {
-		this.mavenSession = mavenSession;
-	}
-
-	@Override
 	public Logger getLog() {
 		return log;
+	}
+
+	@Override
+	public ArtifactInstaller getArtifactInstaller() {
+		return artifactInstaller;
 	}
 	
 }

--- a/src/main/java/org/palladiosimulator/maven/tychotprefresh/tasks/TaskDependenciesInitializable.java
+++ b/src/main/java/org/palladiosimulator/maven/tychotprefresh/tasks/TaskDependenciesInitializable.java
@@ -3,14 +3,11 @@ package org.palladiosimulator.maven.tychotprefresh.tasks;
 import java.util.List;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.execution.MavenSession;
 
 public interface TaskDependenciesInitializable extends TaskDependencies {
-
-	void setMavenSession(MavenSession mavenSession);
 
 	void setRemoteRepositories(List<ArtifactRepository> remoteRepositories);
 
 	void setLocalRepository(ArtifactRepository localRepository);
-
+	
 }


### PR DESCRIPTION
The previous implementation added a temporary project to the reactor,
which caused problems with several other plugins because the project has
never been completely initialized. Instead, we now install the artifact
into the local maven repository. This also avoids temporary files that
are not properly deleted.

The downside of this approach are possible conflicts if two builds use
the same target platform coordinates. This should be avoided.

We should adjust the parent POMs to avoid conflicts.